### PR TITLE
Add: support for multiple networks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,8 @@ import {
   CompilationResult,
 } from "@remixproject/plugin-api"
 
-import { PluginClient } from "@remixproject/plugin";
-import { createClient } from "@remixproject/plugin-webview";
+import { PluginClient } from "@remixproject/plugin"
+import { createClient } from "@remixproject/plugin-webview"
 
 import { AppContext } from "./AppContext"
 import { Routes } from "./routes"
@@ -51,7 +51,8 @@ const App = () => {
       setClientInstance(client)
       console.log("Remix Etherscan Plugin has been loaded")
 
-      client.on("solidity",
+      client.on(
+        "solidity",
         "compilationFinished",
         (
           fileName: string,
@@ -98,14 +99,16 @@ const App = () => {
           if (!clientInstanceRef.current) {
             return
           }
-          const network = await getNetworkName(clientInstanceRef.current)
+          const { network, networkId } = await getNetworkName(
+            clientInstanceRef.current
+          )
           if (network === "vm") {
             return
           }
           const status = await getReceiptStatus(
             item.guid,
             apiKey,
-            getEtherScanApi(network)
+            getEtherScanApi(network, networkId)
           )
           if (status === "Pass - Verified") {
             const newReceipts = receipts.map((currentReceipt: Receipt) => {

--- a/src/utils/networks.ts
+++ b/src/utils/networks.ts
@@ -1,0 +1,21 @@
+export const EtherscanAPIurls = {
+  // all mainnet
+  56: "https://api.bscscan.com/api",
+  137: "https://api.polygonscan.com/api",
+  250: "https://api.ftmscan.com/api",
+  42161: "https://api.arbiscan.io/api",
+  43114: "https://api.snowtrace.io/api",
+  1285: "https://api-moonriver.moonscan.io/api",
+  1284: "https://api-moonbeam.moonscan.io/api",
+  25: "https://api.cronoscan.com/api",
+  199: "https://api.bttcscan.com/api",
+  // all testnet
+  97: "https://api-testnet.bscscan.com/api",
+  80001: "https://api-testnet.polygonscan.com/api",
+  4002: "https://api-testnet.ftmscan.com/api",
+  421611: "https://api-testnet.arbiscan.io/api",
+  43113: "https://api-testnet.snowtrace.io/api",
+  1287: "https://api-moonbase.moonscan.io/api",
+  338: "https://api-testnet.cronoscan.com/api",
+  1028: "https://api-testnet.bttcscan.com/api",
+}

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -1,21 +1,36 @@
 import { PluginClient } from "@remixproject/plugin"
-import axios from 'axios'
+import axios from "axios"
+import { EtherscanAPIurls } from "./networks"
 type RemixClient = PluginClient
 
-export const getEtherScanApi = (network: string) => {
-  return network === "main"
-    ? `https://api.etherscan.io/api`
-    : `https://api-${network}.etherscan.io/api`
+export const getEtherScanApi = (network: string, networkId: any) => {
+  let apiUrl
+
+  if (network === "main") {
+    apiUrl = "https://api.etherscan.io/api"
+  } else if (network === "custom") {
+    if (!(networkId in EtherscanAPIurls)) {
+      throw new Error("no known network to verify against")
+    }
+    apiUrl = (EtherscanAPIurls as any)[networkId]
+  } else {
+    apiUrl = `https://api-${network}.etherscan.io/api`
+  }
+
+  return apiUrl
 }
 
 export const getNetworkName = async (client: RemixClient) => {
   const network = await client.call("network", "detectNetwork")
+
   if (!network) {
     throw new Error("no known network to verify against")
   }
   const name = network.name!.toLowerCase()
-  // TODO : remove that when https://github.com/ethereum/remix-ide/issues/2017 is fixe
-  return name === "görli" ? "goerli" : name
+
+  const id = network.id
+
+  return { network: name, networkId: id }
 }
 
 export const getReceiptStatus = async (

--- a/src/views/ReceiptsView.tsx
+++ b/src/views/ReceiptsView.tsx
@@ -19,12 +19,12 @@ export const ReceiptsView: React.FC = () => {
     apiKey: string
   ) => {
     try {
-      const network = await getNetworkName(clientInstance)
+      const { network, networkId } = await getNetworkName(clientInstance)
       if (network === "vm") {
         setResults("Cannot verify in the selected network")
         return
       }
-      const etherscanApi = getEtherScanApi(network)
+      const etherscanApi = getEtherScanApi(network, networkId)
       const result = await getReceiptStatus(
         values.receiptGuid,
         apiKey,

--- a/src/views/VerifyView.tsx
+++ b/src/views/VerifyView.tsx
@@ -1,15 +1,13 @@
 import React, { useState } from "react"
 
-import {
-  PluginClient,
-} from "@remixproject/plugin"
+import { PluginClient } from "@remixproject/plugin"
 import { Formik, ErrorMessage, Field } from "formik"
 
 import { getNetworkName, getEtherScanApi, getReceiptStatus } from "../utils"
 import { SubmitButton } from "../components"
 import { Receipt } from "../types"
 import { CompilationResult } from "@remixproject/plugin-api"
-import axios from 'axios'
+import axios from "axios"
 
 interface Props {
   client: PluginClient
@@ -89,11 +87,12 @@ export const VerifyView: React.FC<Props> = ({
       contractName: string,
       compilationResultParam: any
     ) => {
-      const network = await getNetworkName(client)
+      const { network, networkId } = await getNetworkName(client)
       if (network === "vm") {
         return "Cannot verify in the selected network"
       }
-      const etherscanApi = getEtherScanApi(network)
+
+      const etherscanApi = getEtherScanApi(network, networkId)
 
       try {
         const contractMetadata = getContractMetadata(
@@ -104,7 +103,7 @@ export const VerifyView: React.FC<Props> = ({
         if (!contractMetadata) {
           return "Please recompile contract"
         }
-        
+
         const contractMetadataParsed = JSON.parse(contractMetadata)
 
         const fileName = getContractFileName(
@@ -113,14 +112,14 @@ export const VerifyView: React.FC<Props> = ({
         )
 
         const jsonInput = {
-          language: 'Solidity',
+          language: "Solidity",
           sources: compilationResultParam.source.sources,
           settings: {
             optimizer: {
               enabled: contractMetadataParsed.settings.optimizer.enabled,
-              runs: contractMetadataParsed.settings.optimizer.runs
-            }
-          }
+              runs: contractMetadataParsed.settings.optimizer.runs,
+            },
+          },
         }
 
         const data: { [key: string]: string | any } = {
@@ -130,7 +129,7 @@ export const VerifyView: React.FC<Props> = ({
           codeformat: "solidity-standard-json-input",
           contractaddress: contractAddress, // Contract Address starts with 0x...
           sourceCode: JSON.stringify(jsonInput),
-          contractname: fileName + ':' + contractName,
+          contractname: fileName + ":" + contractName,
           compilerversion: `v${contractMetadataParsed.compiler.version}`, // see http://etherscan.io/solcversions for list of support versions
           constructorArguements: contractArgumentsParam, // if applicable
         }


### PR DESCRIPTION
Added support for these explorers:

Mainnet:

1. [bscscan.com](https://bscscan.com)
2. [polygonscan.com](https://polygonscan.com)
3. [ftmscan.com](https://ftmscan.com)
4. [arbiscan.io](https://arbiscan.io)
5. [snowtrace.io](https://snowtrace.io)
6. [moonriver.moonscan.io](https://moonriver.moonscan.io)
7. [moonbeam.moonscan.io](https://moonbeam.moonscan.io)
8. [bttcscan.com](https://bttcscan.com)

Testnet:

1. [testnet.bscscan.com](https://testnet.bscscan.com)
2. [mumbai.polygonscan.com](https://mumbai.polygonscan.com)
3. [testnet.ftmscan.com](https://testnet.ftmscan.com)
4. [testnet.arbiscan.io](https://testnet.arbiscan.io)
5. [testnet.snowtrace.io](https://testnet.snowtrace.io)
6. [moonbase.moonscan.io](https://moonbase.moonscan.io)
7. [testnet.cronoscan.com](https://testnet.cronoscan.com)
8. [testnet.bttcscan.com](https://testnet.bttcscan.com)

closes #59, closes #19, closes #36 